### PR TITLE
Fix: truncation text is cut out when the last char is a new line

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 26
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.dinuscxj.ellipsizeexample"
-        minSdkVersion 11
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -20,7 +20,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.2.1'
-    compile project(':ellipsizetextview')
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation project(':ellipsizetextview')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,18 +3,19 @@
 buildscript {
     repositories {
         jcenter()
+        google()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'com.android.tools.build:gradle:3.1.2'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        google()
+        mavenCentral()
     }
 }
 

--- a/ellipsizetextview/build.gradle
+++ b/ellipsizetextview/build.gradle
@@ -1,24 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.2'
-
-    defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 23
-        versionCode 1
-        versionName "1.0"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
+    compileSdkVersion 26
+    buildToolsVersion '27.0.3'
 }
 
-dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.2.1'
-}

--- a/ellipsizetextview/src/main/java/com/dinuscxj/ellipsize/EllipsizeTextView.java
+++ b/ellipsizetextview/src/main/java/com/dinuscxj/ellipsize/EllipsizeTextView.java
@@ -97,7 +97,14 @@ public class EllipsizeTextView extends TextView {
         final int width = layout.getWidth() - getPaddingLeft() - getPaddingRight();
         final int maxLineCount = Math.max(1, computeMaxLineCount(layout));
         final int lastLineWidth = (int) layout.getLineWidth(maxLineCount - 1);
-        final int mLastCharacterIndex = layout.getLineEnd(maxLineCount - 1);
+
+        int mLastCharacterIndex = layout.getLineEnd(maxLineCount - 1);
+
+        // Decrease the last character index if the previous char is a new line char, so to avoid for the truncation
+        // text to be mislaid out
+        while (originText.charAt(mLastCharacterIndex - 1) == '\n' && mLastCharacterIndex > 0) {
+            mLastCharacterIndex--;
+        }
 
         final int suffixWidth = (int) (Layout.getDesiredWidth(mEllipsizeText, getPaint()) +
                 Layout.getDesiredWidth(restSuffixText, getPaint())) + 1;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri May 26 10:30:08 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip


### PR DESCRIPTION
* Gradle cleanup
* Decrease the last character index if the previous char is a new line char, so to avoid for the truncation text to be mislaid out