### PR TITLE
clean up manifest

### DIFF
--- a/ellipsizetextview/src/main/AndroidManifest.xml
+++ b/ellipsizetextview/src/main/AndroidManifest.xml
@@ -2,9 +2,7 @@
     package="com.dinuscxj.ellipsize">
 
     <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
+        android:label="@string/app_name">
 
     </application>
 


### PR DESCRIPTION
Having supportRtl and allowBackup is making merge conflicts for our APP manifest. As this lib doesn't need them, I cleaned them up from here